### PR TITLE
Update gitignore to ignore local.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.iml
 .gradle
 /currentPosition.properties
+/local.properties
 /.idea/workspace.xml
 /.idea/libraries
 /.idea

--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your currentPosition configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Mon Jan 07 14:28:58 CST 2019
-sdk.dir=C\:\\androidSDK


### PR DESCRIPTION
`local.properties` is per-user, and should not be checked into Git. This PR updates the Gitignore to reflect that.

Tagging @WangDaYeeeeee for review.