### PR TITLE
Remove local.properties from version control

### DIFF
--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your currentPosition configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Mon Jan 07 14:28:58 CST 2019
-sdk.dir=C\:\\androidSDK


### PR DESCRIPTION
[My original pull request](https://github.com/WangDaYeeeeee/GeometricWeather/pull/141) removed `local.properties` from version control, but it got added back in a later commit. This is problematic; even if the file is gitignored (as it is now with my original PR merged), it will still count changes if the file is already checked in. This causes problems when other developers (like me) open the project on our own machines. The version of `local.properties` checked into Git must be fully gone for everything to work correctly. This PR re-removes it.

Note that having it removed from Git has **no effect** on the `local.properties` specific to your system. There should be no behavior change.

Tagging @WangDaYeeeeee for review.