### PR TITLE
[MF] Fix crash if API gives us null for temperature

### DIFF
--- a/app/src/main/java/wangdaye/com/geometricweather/weather/converters/MfResultConverter.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/weather/converters/MfResultConverter.java
@@ -291,7 +291,9 @@ public class MfResultConverter {
     }
 
     private static HalfDay getHalfDay(boolean isDaytime, List<Hourly> hourly, MfForecastResult.DailyForecast dailyForecast) {
-        Integer temp = isDaytime ? toInt(dailyForecast.temperature.max) : toInt(dailyForecast.temperature.min);
+        Integer temp = isDaytime
+                ? (dailyForecast.temperature.max == null ? 0 : toInt(dailyForecast.temperature.max)) // FIXME: Temperature is not nullable
+                : (dailyForecast.temperature.min == null ? 0 : toInt(dailyForecast.temperature.min)); // FIXME: Temperature is not nullable
         Integer tempWindChill = null;
 
         Float precipitationTotal = 0.0f;


### PR DESCRIPTION
Sorry for missing this one when fixing other issues.

Additionally, would it be possible to make the temperature @Nullable?
For forecast in 15 days, sometimes the min or max temperature is missing so I put 0 degrees instead as a workaround, but it's wrong...