### PR TITLE
Fix capital letter on notification + French fixes

### DIFF
--- a/app/src/main/java/wangdaye/com/geometricweather/remoteviews/presenters/notification/ForecastNotificationIMP.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/remoteviews/presenters/notification/ForecastNotificationIMP.java
@@ -102,18 +102,18 @@ public class ForecastNotificationIMP extends AbstractRemoteViewsPresenter {
 
         // title and content.
         if (today) {
-            builder.setContentTitle(context.getString(R.string.day)
+            builder.setContentTitle(context.getString(R.string.daytime)
                     + " " + weather.getDailyForecast().get(0).day().getWeatherText()
                     + " " + weather.getDailyForecast().get(0).day().getTemperature().getTemperature(context, temperatureUnit)
-            ).setContentText(context.getString(R.string.night)
+            ).setContentText(context.getString(R.string.nighttime)
                     + " " + weather.getDailyForecast().get(0).night().getWeatherText()
                     + " " + weather.getDailyForecast().get(0).night().getTemperature().getTemperature(context, temperatureUnit)
             );
         } else {
-            builder.setContentTitle(context.getString(R.string.day)
+            builder.setContentTitle(context.getString(R.string.daytime)
                     + " " + weather.getDailyForecast().get(1).day().getWeatherText()
                     + " " + weather.getDailyForecast().get(1).day().getTemperature().getTemperature(context, temperatureUnit)
-            ).setContentText(context.getString(R.string.night)
+            ).setContentText(context.getString(R.string.nighttime)
                     + " " + weather.getDailyForecast().get(1).night().getWeatherText()
                     + " " + weather.getDailyForecast().get(1).night().getTemperature().getTemperature(context, temperatureUnit)
             );

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -30,7 +30,7 @@
     <string name="hours_of_sun">Heures d’ensoleillement</string>
     <string name="forecast">Prévisions</string>
     <string name="briefings">Bulletin</string>
-    <string name="daytime">Jour</string>
+    <string name="daytime">Journée</string>
     <string name="nighttime">Nuit</string>
     <string name="publish_at">Actualisé à</string>
     <string name="feels_like">Ressenti</string>
@@ -319,15 +319,15 @@
     <string name="action_appStore">Magasin d’applications</string>
 
     <!-- widget -->
-    <string name="widget_day">Journée</string>
+    <string name="widget_day">Jour</string>
     <string name="widget_week">Semaine</string>
-    <string name="widget_day_week">Journée + Semaine</string>
-    <string name="widget_clock_day_horizontal">Horloge + Journée (à l’horizontale)</string>
-    <string name="widget_clock_day_details">Horloge + Journée (détaillé)</string>
-    <string name="widget_clock_day_vertical">Horloge + Journée (à la verticale)</string>
-    <string name="widget_clock_day_week">Horloge + Journée + Semaine</string>
+    <string name="widget_day_week">Jours + Semaine</string>
+    <string name="widget_clock_day_horizontal">Horloge + Jours (à l’horizontale)</string>
+    <string name="widget_clock_day_details">Horloge + Jours (détaillé)</string>
+    <string name="widget_clock_day_vertical">Horloge + Jours (à la verticale)</string>
+    <string name="widget_clock_day_week">Horloge + Jours + Semaine</string>
     <string name="widget_text">Textuel</string>
-    <string name="widget_trend_daily">Tendances journalières</string>
+    <string name="widget_trend_daily">Tendances quotidiennes</string>
     <string name="widget_trend_hourly">Tendances heure par heure</string>
     <string name="widget_multi_city">Plusieurs villes</string>
     <string name="wait_refresh">patientez</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -26,7 +26,7 @@
     <string name="wind_level">Niveau de vent</string>
     <string name="sensible_temp">Temp. ressentie</string>
     <string name="humidity">Humidité</string>
-    <string name="uv_index">Index UV</string>
+    <string name="uv_index">Indice UV</string>
     <string name="hours_of_sun">Heures d’ensoleillement</string>
     <string name="forecast">Prévisions</string>
     <string name="briefings">Bulletin</string>


### PR DESCRIPTION
Notifications now use the string translation that has a capital letter for "daytime" and "nighttime" instead of beginning with a lowercase.

Few improvements to the French translation, hopefully this should be the last ones for a while.