### PR TITLE
Providers configuration: fix #67 #116 #152 #222

### DIFF
--- a/app/src/main/java/wangdaye/com/geometricweather/location/services/ip/BaiduIPLocationService.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/location/services/ip/BaiduIPLocationService.java
@@ -12,6 +12,7 @@ import wangdaye.com.geometricweather.location.services.LocationService;
 import wangdaye.com.geometricweather.common.rxjava.SchedulerTransformer;
 import wangdaye.com.geometricweather.common.rxjava.BaseObserver;
 import wangdaye.com.geometricweather.common.rxjava.ObserverContainer;
+import wangdaye.com.geometricweather.settings.SettingsManager;
 
 public class BaiduIPLocationService extends LocationService {
 
@@ -27,7 +28,7 @@ public class BaiduIPLocationService extends LocationService {
 
     @Override
     public void requestLocation(Context context, @NonNull LocationCallback callback) {
-        mApi.getLocation(BuildConfig.BAIDU_IP_LOCATION_AK, "gcj02")
+        mApi.getLocation(SettingsManager.getInstance(context).getProviderBaiduIpLocationAk(true), "gcj02")
                 .compose(SchedulerTransformer.create())
                 .subscribe(new ObserverContainer<>(compositeDisposable, new BaseObserver<BaiduIPLocationResult>() {
                     @Override

--- a/app/src/main/java/wangdaye/com/geometricweather/settings/SettingsManager.kt
+++ b/app/src/main/java/wangdaye/com/geometricweather/settings/SettingsManager.kt
@@ -3,6 +3,7 @@ package wangdaye.com.geometricweather.settings
 import android.content.Context
 import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
+import wangdaye.com.geometricweather.BuildConfig
 import wangdaye.com.geometricweather.R
 import wangdaye.com.geometricweather.common.basic.models.options.*
 import wangdaye.com.geometricweather.common.basic.models.options.appearance.CardDisplay
@@ -107,6 +108,19 @@ class SettingsManager private constructor(context: Context){
     private val notificationHideIconEnabled = context.getString(R.string.key_notification_hide_icon)
     private val notificationHideInLockScreenEnabled = context.getString(R.string.key_notification_hide_in_lockScreen)
     private val notificationHideBigViewEnabled = context.getString(R.string.key_notification_hide_big_view)
+
+    // service providers
+    private val providerAccuWeatherKey = context.getString(R.string.key_provider_accu_weather_key)
+    private val providerAccuCurrentKey = context.getString(R.string.key_provider_accu_current_key)
+    private val providerAccuAqiKey = context.getString(R.string.key_provider_accu_aqi_key)
+
+    private val providerOwmKey = context.getString(R.string.key_provider_owm_key)
+
+    private val providerBaiduIpLocationAk = context.getString(R.string.key_provider_baidu_ip_location_ak)
+
+    private val providerMfWsftKey = context.getString(R.string.key_provider_mf_wsft_key)
+    private val providerIqaAirParifKey = context.getString(R.string.key_provider_iqa_air_parif_key)
+    private val providerIqaAtmoAuraKey = context.getString(R.string.key_provider_iqa_atmo_aura_key)
 
     fun preload() {
         config.preload()
@@ -325,5 +339,47 @@ class SettingsManager private constructor(context: Context){
 
     fun isNotificationHideBigViewEnabled(): Boolean {
         return config.getBoolean(notificationHideBigViewEnabled, false)
+    }
+
+    private fun getProviderSettingValue(key: String, defaultValue: String?, useDefaultValue: Boolean): String? {
+        val prefValue = config.getString(key, "")
+
+        return if (prefValue == null || prefValue.isEmpty()) {
+            if(useDefaultValue) defaultValue else null
+        } else {
+            prefValue
+        }
+    }
+
+    fun getProviderAccuWeatherKey(useDefaultValue: Boolean): String? {
+        return getProviderSettingValue(providerAccuWeatherKey, BuildConfig.ACCU_WEATHER_KEY, useDefaultValue);
+    }
+
+    fun getProviderAccuCurrentKey(useDefaultValue: Boolean): String? {
+        return getProviderSettingValue(providerAccuCurrentKey, BuildConfig.ACCU_CURRENT_KEY, useDefaultValue);
+    }
+
+    fun getProviderAccuAqiKey(useDefaultValue: Boolean): String? {
+        return getProviderSettingValue(providerAccuAqiKey, BuildConfig.ACCU_AQI_KEY, useDefaultValue);
+    }
+
+    fun getProviderOwmKey(useDefaultValue: Boolean): String? {
+        return getProviderSettingValue(providerOwmKey, BuildConfig.OWM_KEY, useDefaultValue);
+    }
+
+    fun getProviderBaiduIpLocationAk(useDefaultValue: Boolean): String? {
+        return getProviderSettingValue(providerBaiduIpLocationAk, BuildConfig.BAIDU_IP_LOCATION_AK, useDefaultValue);
+    }
+
+    fun getProviderMfWsftKey(useDefaultValue: Boolean): String? {
+        return getProviderSettingValue(providerMfWsftKey, BuildConfig.MF_WSFT_KEY, useDefaultValue);
+    }
+
+    fun getProviderIqaAirParifKey(useDefaultValue: Boolean): String? {
+        return getProviderSettingValue(providerIqaAirParifKey, BuildConfig.IQA_AIR_PARIF_KEY, useDefaultValue);
+    }
+
+    fun getProviderIqaAtmoAuraKey(useDefaultValue: Boolean): String? {
+        return getProviderSettingValue(providerIqaAtmoAuraKey, BuildConfig.IQA_ATMO_AURA_KEY, useDefaultValue);
     }
 }

--- a/app/src/main/java/wangdaye/com/geometricweather/settings/fragments/ServiceProviderAdvancedSettingsFragment.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/settings/fragments/ServiceProviderAdvancedSettingsFragment.java
@@ -1,0 +1,52 @@
+package wangdaye.com.geometricweather.settings.fragments;
+
+import android.os.Bundle;
+
+import androidx.preference.EditTextPreference;
+
+import wangdaye.com.geometricweather.R;
+
+/**
+ * Service provider settings fragment.
+ */
+
+public class ServiceProviderAdvancedSettingsFragment extends AbstractSettingsFragment {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.perference_service_provider_advanced);
+        initPreferences();
+    }
+
+    @Override
+    public void onCreatePreferences(Bundle bundle, String s) {
+        // do nothing.
+    }
+
+    private void initPreferences() {
+        initPreference(R.string.key_provider_accu_weather_key, getSettingsOptionManager().getProviderAccuWeatherKey(false));
+        initPreference(R.string.key_provider_accu_current_key, getSettingsOptionManager().getProviderAccuCurrentKey(false));
+        initPreference(R.string.key_provider_accu_aqi_key, getSettingsOptionManager().getProviderAccuAqiKey(false));
+        initPreference(R.string.key_provider_owm_key, getSettingsOptionManager().getProviderOwmKey(false));
+        initPreference(R.string.key_provider_baidu_ip_location_ak, getSettingsOptionManager().getProviderBaiduIpLocationAk(false));
+        initPreference(R.string.key_provider_mf_wsft_key, getSettingsOptionManager().getProviderMfWsftKey(false));
+        initPreference(R.string.key_provider_iqa_air_parif_key, getSettingsOptionManager().getProviderIqaAirParifKey(false));
+        initPreference(R.string.key_provider_iqa_atmo_aura_key, getSettingsOptionManager().getProviderIqaAtmoAuraKey(false));
+    }
+
+    private void initPreference(int stringKey, String currentValue) {
+        EditTextPreference pref = findPreference(getString(stringKey));
+        pref.setSummary(currentValue != null ? currentValue : getString(R.string.settings_provider_default_value));
+        pref.setText(currentValue);
+        pref.setOnPreferenceChangeListener((preference, newValue) -> {
+            // Allow to reset to default value if left empty
+            if (newValue.toString().isEmpty()) {
+                preference.setSummary(getString(R.string.settings_provider_default_value));
+            } else {
+                preference.setSummary(newValue.toString());
+            }
+            return true;
+        });
+    }
+}

--- a/app/src/main/java/wangdaye/com/geometricweather/settings/fragments/ServiceProviderSettingsFragment.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/settings/fragments/ServiceProviderSettingsFragment.java
@@ -125,6 +125,12 @@ public class ServiceProviderSettingsFragment extends AbstractSettingsFragment {
             );
             return true;
         });
+
+        // service provider.
+        findPreference(getString(R.string.key_service_provider_advanced)).setOnPreferenceClickListener(preference -> {
+            pushFragment(new ServiceProviderAdvancedSettingsFragment(), preference.getKey());
+            return true;
+        });
     }
 
     private static void setListPreferenceValues(ListPreference pref, List<CharSequence> entries, List<CharSequence> values) {

--- a/app/src/main/java/wangdaye/com/geometricweather/weather/services/AccuWeatherService.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/weather/services/AccuWeatherService.java
@@ -96,16 +96,16 @@ public class AccuWeatherService extends WeatherService {
         String languageCode = SettingsManager.getInstance(context).getLanguage().getCode();
 
         Observable<List<AccuCurrentResult>> realtime = mApi.getCurrent(
-                location.getCityId(), BuildConfig.ACCU_CURRENT_KEY, languageCode, true);
+                location.getCityId(), SettingsManager.getInstance(context).getProviderAccuCurrentKey(true), languageCode, true);
 
         Observable<AccuDailyResult> daily = mApi.getDaily(
-                location.getCityId(), BuildConfig.ACCU_WEATHER_KEY, languageCode, true, true);
+                location.getCityId(), SettingsManager.getInstance(context).getProviderAccuWeatherKey(true), languageCode, true, true);
 
         Observable<List<AccuHourlyResult>> hourly = mApi.getHourly(
-                location.getCityId(), BuildConfig.ACCU_WEATHER_KEY, languageCode, true);
+                location.getCityId(), SettingsManager.getInstance(context).getProviderAccuWeatherKey(true), languageCode, true);
 
         Observable<AccuMinuteResult> minute = mApi.getMinutely(
-                BuildConfig.ACCU_WEATHER_KEY,
+                SettingsManager.getInstance(context).getProviderAccuWeatherKey(true),
                 languageCode,
                 true,
                 location.getLatitude() + "," + location.getLongitude()
@@ -114,11 +114,11 @@ public class AccuWeatherService extends WeatherService {
         );
 
         Observable<List<AccuAlertResult>> alert = mApi.getAlert(
-                location.getCityId(), BuildConfig.ACCU_WEATHER_KEY, languageCode, true);
+                location.getCityId(), SettingsManager.getInstance(context).getProviderAccuWeatherKey(true), languageCode, true);
 
         Observable<AccuAqiResult> aqi = mApi.getAirQuality(
                 location.getCityId(),
-                BuildConfig.ACCU_AQI_KEY
+                SettingsManager.getInstance(context).getProviderAccuAqiKey(true)
         ).onExceptionResumeNext(
                 Observable.create(emitter -> emitter.onNext(new EmptyAqiResult()))
         );
@@ -164,7 +164,7 @@ public class AccuWeatherService extends WeatherService {
         try {
             resultList = mApi.callWeatherLocation(
                     "Always",
-                    BuildConfig.ACCU_WEATHER_KEY,
+                    SettingsManager.getInstance(context).getProviderAccuWeatherKey(true),
                     query,
                     languageCode
             ).execute().body();
@@ -217,7 +217,7 @@ public class AccuWeatherService extends WeatherService {
 
         mApi.getWeatherLocationByGeoPosition(
                 "Always",
-                BuildConfig.ACCU_WEATHER_KEY,
+                SettingsManager.getInstance(context).getProviderAccuWeatherKey(true),
                 location.getLatitude() + "," + location.getLongitude(),
                 languageCode
         ).compose(SchedulerTransformer.create())
@@ -247,7 +247,7 @@ public class AccuWeatherService extends WeatherService {
         String languageCode = SettingsManager.getInstance(context).getLanguage().getCode();
         String zipCode = query.matches("[a-zA-Z0-9]") ? query : null;
 
-        mApi.getWeatherLocation("Always", BuildConfig.ACCU_WEATHER_KEY, query, languageCode)
+        mApi.getWeatherLocation("Always", SettingsManager.getInstance(context).getProviderAccuWeatherKey(true), query, languageCode)
                 .compose(SchedulerTransformer.create())
                 .subscribe(new ObserverContainer<>(mCompositeDisposable, new BaseObserver<List<AccuLocationResult>>() {
                     @Override

--- a/app/src/main/java/wangdaye/com/geometricweather/weather/services/MfWeatherService.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/weather/services/MfWeatherService.java
@@ -101,24 +101,24 @@ public class MfWeatherService extends WeatherService {
         String languageCode = SettingsManager.getInstance(context).getLanguage().getCode();
 
         Observable<MfCurrentResult> current = mMfApi.getCurrent(
-                location.getLatitude(), location.getLongitude(), languageCode, BuildConfig.MF_WSFT_KEY);
+                location.getLatitude(), location.getLongitude(), languageCode, SettingsManager.getInstance(context).getProviderMfWsftKey(true));
 
         Observable<MfForecastResult> forecast = mMfApi.getForecast(
-                location.getLatitude(), location.getLongitude(), languageCode, BuildConfig.MF_WSFT_KEY);
+                location.getLatitude(), location.getLongitude(), languageCode, SettingsManager.getInstance(context).getProviderMfWsftKey(true));
 
         // TODO: Will allow us to display forecast for day and night in daily
         //Observable<MfForecastResult> dayNightForecast = api.getForecastInstants(
-        //        location.getLatitude(), location.getLongitude(), languageCode, "afternoon,night", BuildConfig.MF_WSFT_KEY);
+        //        location.getLatitude(), location.getLongitude(), languageCode, "afternoon,night", SettingsManager.getInstance(context).getProviderMfWsftKey(true));
 
         Observable<MfEphemerisResult> ephemeris = mMfApi.getEphemeris(
-                location.getLatitude(), location.getLongitude(), "en", BuildConfig.MF_WSFT_KEY);
+                location.getLatitude(), location.getLongitude(), "en", SettingsManager.getInstance(context).getProviderMfWsftKey(true));
         // English required to convert moon phase
 
         Observable<MfRainResult> rain = mMfApi.getRain(
-                location.getLatitude(), location.getLongitude(), languageCode, BuildConfig.MF_WSFT_KEY);
+                location.getLatitude(), location.getLongitude(), languageCode, SettingsManager.getInstance(context).getProviderMfWsftKey(true));
 
         Observable<MfWarningsResult> warnings = mMfApi.getWarnings(
-                location.getProvince(), null, BuildConfig.MF_WSFT_KEY
+                location.getProvince(), null, SettingsManager.getInstance(context).getProviderMfWsftKey(true)
         ).onExceptionResumeNext(
                 // FIXME: Will not report warnings if current location was searched through AccuWeather search because "province" is not the department
                 Observable.create(emitter -> emitter.onNext(new EmptyWarningsResult()))
@@ -135,7 +135,7 @@ public class MfWeatherService extends WeatherService {
                 || location.getProvince().equals("69") || location.getProvince().equals("73")
                 || location.getProvince().equals("74")) {
             aqiAtmoAura = mAtmoAuraApi.getQAFull(
-                    BuildConfig.IQA_ATMO_AURA_KEY,
+                    SettingsManager.getInstance(context).getProviderIqaAtmoAuraKey(true),
                     String.valueOf(location.getLatitude()),
                     String.valueOf(location.getLongitude())
             ).onExceptionResumeNext(
@@ -180,7 +180,7 @@ public class MfWeatherService extends WeatherService {
     public List<Location> requestLocation(Context context, String query) {
         List<MfLocationResult> resultList = null;
         try {
-            resultList = mMfApi.callWeatherLocation(query, 48.86d, 2.34d, BuildConfig.MF_WSFT_KEY).execute().body();
+            resultList = mMfApi.callWeatherLocation(query, 48.86d, 2.34d, SettingsManager.getInstance(context).getProviderMfWsftKey(true)).execute().body();
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -232,7 +232,7 @@ public class MfWeatherService extends WeatherService {
                 location.getLatitude(),
                 location.getLongitude(),
                 languageCode,
-                BuildConfig.MF_WSFT_KEY
+                SettingsManager.getInstance(context).getProviderMfWsftKey(true)
         ).compose(SchedulerTransformer.create())
                 .subscribe(new ObserverContainer<>(mCompositeDisposable, new BaseObserver<MfForecastV2Result>() {
                     @Override
@@ -261,7 +261,7 @@ public class MfWeatherService extends WeatherService {
 
     public void requestLocation(Context context, String query,
                                 @NonNull RequestLocationCallback callback) {
-        mMfApi.getWeatherLocation(query, 48.86d, 2.34d, BuildConfig.MF_WSFT_KEY)
+        mMfApi.getWeatherLocation(query, 48.86d, 2.34d, SettingsManager.getInstance(context).getProviderMfWsftKey(true))
                 .compose(SchedulerTransformer.create())
                 .subscribe(new ObserverContainer<>(mCompositeDisposable, new BaseObserver<List<MfLocationResult>>() {
                     @Override

--- a/app/src/main/java/wangdaye/com/geometricweather/weather/services/OwmWeatherService.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/weather/services/OwmWeatherService.java
@@ -90,16 +90,16 @@ public class OwmWeatherService extends WeatherService {
         String languageCode = SettingsManager.getInstance(context).getLanguage().getCode();
 
         Observable<OwmOneCallResult> oneCall = mApi.getOneCall(
-                BuildConfig.OWM_KEY, location.getLatitude(), location.getLongitude(), "metric", languageCode);
+                SettingsManager.getInstance(context).getProviderOwmKey(true), location.getLatitude(), location.getLongitude(), "metric", languageCode);
 
         Observable<OwmAirPollutionResult> airPollutionCurrent = mApi.getAirPollutionCurrent(
-                BuildConfig.OWM_KEY, location.getLatitude(), location.getLongitude()
+                SettingsManager.getInstance(context).getProviderOwmKey(true), location.getLatitude(), location.getLongitude()
         ).onExceptionResumeNext(
                 Observable.create(emitter -> emitter.onNext(new EmptyAqiResult()))
         );
 
         Observable<OwmAirPollutionResult> airPollutionForecast = mApi.getAirPollutionForecast(
-                BuildConfig.OWM_KEY, location.getLatitude(), location.getLongitude()
+                SettingsManager.getInstance(context).getProviderOwmKey(true), location.getLatitude(), location.getLongitude()
         ).onExceptionResumeNext(
                 Observable.create(emitter -> emitter.onNext(new EmptyAqiResult()))
         );
@@ -136,7 +136,7 @@ public class OwmWeatherService extends WeatherService {
     public List<Location> requestLocation(Context context, String query) {
         List<OwmLocationResult> resultList = null;
         try {
-            resultList = mApi.callWeatherLocation(BuildConfig.OWM_KEY, query).execute().body();
+            resultList = mApi.callWeatherLocation(SettingsManager.getInstance(context).getProviderOwmKey(true), query).execute().body();
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -184,7 +184,7 @@ public class OwmWeatherService extends WeatherService {
         final CacheLocationRequestCallback finalCallback = new CacheLocationRequestCallback(context, callback);
 
         mApi.getWeatherLocationByGeoPosition(
-                BuildConfig.OWM_KEY, location.getLatitude(), location.getLongitude()
+                SettingsManager.getInstance(context).getProviderOwmKey(true), location.getLatitude(), location.getLongitude()
         ).compose(SchedulerTransformer.create())
                 .subscribe(new ObserverContainer<>(mCompositeDisposable, new BaseObserver<List<OwmLocationResult>>() {
                     @Override
@@ -211,7 +211,7 @@ public class OwmWeatherService extends WeatherService {
                                 @NonNull RequestLocationCallback callback) {
         String zipCode = query.matches("[a-zA-Z0-9]") ? query : null;
 
-        mApi.getWeatherLocation(BuildConfig.OWM_KEY, query)
+        mApi.getWeatherLocation(SettingsManager.getInstance(context).getProviderOwmKey(true), query)
                 .compose(SchedulerTransformer.create())
                 .subscribe(new ObserverContainer<>(mCompositeDisposable, new BaseObserver<List<OwmLocationResult>>() {
                     @Override

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -342,6 +342,8 @@
     <string name="settings_summary_live_wallpaper">Définir une animation météo Material en tant que fond d’écran animé</string>
     <string name="settings_title_service_provider">Fournisseur de service</string>
     <string name="settings_summary_service_provider">Sélectionner un fournisseur de service de données météo et de recherche d’emplacement</string>
+    <string name="settings_title_service_provider_advanced">Options avancées des fournisseurs de service</string>
+    <string name="settings_summary_service_provider_advanced">À modifier avec prudence</string>
     <string name="settings_title_weather_source">Source des données météo</string>
     <string name="settings_title_location_service">Service de recherche d’emplacement</string>
     <string name="settings_title_dark_mode">Mode sombre</string>
@@ -400,4 +402,5 @@
     <string name="settings_title_notification_hide_big_view">Vue large</string>
     <string name="settings_notification_hide_big_view_on">Masquer</string>
     <string name="settings_notification_hide_big_view_off">Afficher</string>
+    <string name="settings_provider_default_value">Par défaut (inchangé)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -370,6 +370,8 @@
     <string name="settings_summary_live_wallpaper">Set Material weather animation as live wallpaper</string>
     <string name="settings_title_service_provider">Service provider</string>
     <string name="settings_summary_service_provider">Select service provider of weather data and location information</string>
+    <string name="settings_title_service_provider_advanced">Advanced service provider settings</string>
+    <string name="settings_summary_service_provider_advanced">Proceed with caution</string>
     <string name="settings_title_weather_source">Weather source</string>
     <string name="settings_title_location_service">Location service</string>
     <string name="settings_title_dark_mode">Dark mode</string>
@@ -428,6 +430,19 @@
     <string name="settings_title_notification_hide_big_view">Extended style</string>
     <string name="settings_notification_hide_big_view_on">Hide</string>
     <string name="settings_notification_hide_big_view_off">Show</string>
+    <string name="settings_provider_default_value">Default (unchanged)</string>
+    <string name="settings_provider_accu_weather">AccuWeather</string>
+    <string name="settings_provider_accu_weather_key">AccuWeather weather key</string>
+    <string name="settings_provider_accu_current_key">AccuWeather current key</string>
+    <string name="settings_provider_accu_aqi_key">AccuWeather AQI key</string>
+    <string name="settings_provider_owm">OpenWeather</string>
+    <string name="settings_provider_owm_key">OpenWeather key</string>
+    <string name="settings_provider_baidu_ip_location">Baidu IP location</string>
+    <string name="settings_provider_baidu_ip_location_ak">Baidu IP location AK</string>
+    <string name="settings_provider_mf">Météo France</string>
+    <string name="settings_provider_mf_wsft_key">Météo France WSFT key</string>
+    <string name="settings_provider_iqa_air_parif_key">Air Parif key</string>
+    <string name="settings_provider_iqa_atmo_aura_key">ATMO AURA key</string>
 
     <!--share preference-->
     <!-- Do not translate the following set of strings. -->
@@ -457,6 +472,7 @@
     <string name="key_background_free">background_free_3</string>
     <string name="key_live_wallpaper">live_wallpaper</string>
     <string name="key_service_provider">service_provider</string>
+    <string name="key_service_provider_advanced">service_provider_advanced</string>
     <string name="key_weather_source">weather_source</string>
     <string name="key_location_service">location_service</string>
     <string name="key_dark_mode">dark_mode</string>
@@ -511,6 +527,14 @@
     <string name="key_notification_hide_icon">hide_notification_icon</string>
     <string name="key_notification_hide_in_lockScreen">hide_notification_in_lockScreen</string>
     <string name="key_notification_hide_big_view">hide_notification_big_view</string>
+    <string name="key_provider_accu_weather_key">provider_accu_weather_key</string>
+    <string name="key_provider_accu_current_key">provider_accu_current_key</string>
+    <string name="key_provider_accu_aqi_key">provider_accu_aqi_key</string>
+    <string name="key_provider_owm_key">provider_owm_key</string>
+    <string name="key_provider_baidu_ip_location_ak">provider_baidu_ip_location_ak</string>
+    <string name="key_provider_mf_wsft_key">provider_mf_wsft_key</string>
+    <string name="key_provider_iqa_air_parif_key">provider_iqa_air_parif_key</string>
+    <string name="key_provider_iqa_atmo_aura_key">provider_iqa_atmo_aura_key</string>
 
     <!-- transition. -->
     <!-- Do not translate the following set of strings. -->

--- a/app/src/main/res/xml/perference_service_provider.xml
+++ b/app/src/main/res/xml/perference_service_provider.xml
@@ -18,4 +18,9 @@
         android:dialogTitle="@string/settings_title_location_service"
         android:defaultValue="native" />
 
+    <Preference
+        android:title="@string/settings_title_service_provider_advanced"
+        android:key="@string/key_service_provider_advanced"
+        android:summary="@string/settings_summary_service_provider_advanced" />
+
 </PreferenceScreen>

--- a/app/src/main/res/xml/perference_service_provider_advanced.xml
+++ b/app/src/main/res/xml/perference_service_provider_advanced.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    android:title="@string/settings_title_service_provider_advanced">
+    <PreferenceCategory
+        android:title="@string/settings_provider_accu_weather">
+        <EditTextPreference
+            android:title="@string/settings_provider_accu_weather_key"
+            android:key="@string/key_provider_accu_weather_key" />
+
+        <EditTextPreference
+            android:title="@string/settings_provider_accu_current_key"
+            android:key="@string/key_provider_accu_current_key" />
+
+        <EditTextPreference
+            android:title="@string/settings_provider_accu_aqi_key"
+            android:key="@string/key_provider_accu_aqi_key" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/settings_provider_owm">
+        <EditTextPreference
+            android:title="@string/settings_provider_owm_key"
+            android:key="@string/key_provider_owm_key" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/settings_provider_baidu_ip_location">
+        <EditTextPreference
+            android:title="@string/settings_provider_baidu_ip_location_ak"
+            android:key="@string/key_provider_baidu_ip_location_ak" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/settings_provider_mf">
+        <EditTextPreference
+            android:title="@string/settings_provider_mf_wsft_key"
+            android:key="@string/key_provider_mf_wsft_key" />
+
+        <EditTextPreference
+            android:title="@string/settings_provider_iqa_air_parif_key"
+            android:key="@string/key_provider_iqa_air_parif_key" />
+
+        <EditTextPreference
+            android:title="@string/settings_provider_iqa_atmo_aura_key"
+            android:key="@string/key_provider_iqa_atmo_aura_key" />
+    </PreferenceCategory>
+</PreferenceScreen>


### PR DESCRIPTION
Fix #67, fix #116, fix #152, fix #222

What has been done:
* [x] Display preferences in settings
* [x] Be able to edit preference value
* [x] Be able to save preference value
* [x] In API calls, use saved preference value instead of BuildConfig
* [x] Allow to reset value to default by editing text to "empty"

<img src="https://user-images.githubusercontent.com/1449159/115994609-062c0800-a5d8-11eb-8ec8-dc9ab34a90d2.png" width="300" /> <img src="https://user-images.githubusercontent.com/1449159/116001072-0e457100-a5f3-11eb-9043-192d9ec68211.png" width="300" />