### PR TITLE
Accu: Migrate AQI to new API v2 (untested)

### DIFF
--- a/app/src/main/java/wangdaye/com/geometricweather/weather/apis/AccuWeatherApi.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/weather/apis/AccuWeatherApi.java
@@ -64,9 +64,10 @@ public interface AccuWeatherApi {
                                              @Query("details") boolean details,
                                              @Query("q") String q);
 
-    @GET("airquality/v1/observations/{city_key}.json")
+    @GET("airquality/v2/forecasts/observations/{city_key}")
     Observable<AccuAqiResult> getAirQuality(@Path("city_key") String city_key,
-                                            @Query("apikey") String apikey);
+                                            @Query("apikey") String apikey,
+                                            @Query("language") String language);
 
     @GET("alerts/v1/{city_key}.json")
     Observable<List<AccuAlertResult>> getAlert(@Path("city_key") String city_key,

--- a/app/src/main/java/wangdaye/com/geometricweather/weather/converters/AccuResultConverter.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/weather/converters/AccuResultConverter.java
@@ -158,16 +158,7 @@ public class AccuResultConverter {
                             aqiResult == null ? new AirQuality(
                                     null, null, null, null,
                                     null, null, null, null
-                            ) : new AirQuality(
-                                    CommonConverter.getAqiQuality(context, aqiResult.Index),
-                                    aqiResult.Index,
-                                    aqiResult.ParticulateMatter2_5,
-                                    aqiResult.ParticulateMatter10,
-                                    aqiResult.SulfurDioxide,
-                                    aqiResult.NitrogenDioxide,
-                                    aqiResult.Ozone,
-                                    aqiResult.CarbonMonoxide
-                            ),
+                            ) : getAirQuality(context, aqiResult),
                             (float) currentResult.RelativeHumidity,
                             (float) currentResult.Pressure.Metric.Value,
                             (float) currentResult.Visibility.Metric.Value,
@@ -196,6 +187,43 @@ public class AccuResultConverter {
         } catch (Exception ignored) {
             return new WeatherService.WeatherResultWrapper(null);
         }
+    }
+
+    private static AirQuality getAirQuality(Context context, AccuAqiResult aqiResult) {
+        Float ParticulateMatter2_5 = null;
+        Float ParticulateMatter10 = null;
+        Float SulfurDioxide = null;
+        Float NitrogenDioxide = null;
+        Float Ozone = null;
+        Float CarbonMonoxide = null;
+
+        for (AccuAqiResult.AqiData.Pollutant pollutant : aqiResult.data.get(0).pollutants) {
+            switch (pollutant.type) {
+                case "PM2.5":
+                    ParticulateMatter2_5 = pollutant.concentration.value;
+                case "PM10":
+                    ParticulateMatter10 = pollutant.concentration.value;
+                case "No2":
+                    NitrogenDioxide = pollutant.concentration.value;
+                case "O3":
+                    Ozone = pollutant.concentration.value;
+                case "CO":
+                    CarbonMonoxide = pollutant.concentration.value;
+                case "SO2":
+                    SulfurDioxide = pollutant.concentration.value;
+            }
+        }
+
+        return new AirQuality(
+                CommonConverter.getAqiQuality(context, aqiResult.data.get(0).overallIndex),
+                aqiResult.data.get(0).overallIndex,
+                ParticulateMatter2_5,
+                ParticulateMatter10,
+                SulfurDioxide,
+                NitrogenDioxide,
+                Ozone,
+                CarbonMonoxide
+        );
     }
 
     private static List<Daily> getDailyList(Context context, AccuDailyResult dailyResult) {

--- a/app/src/main/java/wangdaye/com/geometricweather/weather/json/accu/AccuAqiResult.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/weather/json/accu/AccuAqiResult.java
@@ -1,6 +1,7 @@
 package wangdaye.com.geometricweather.weather.json.accu;
 
 import java.util.Date;
+import java.util.List;
 
 /**
  * Accu aqi result.
@@ -9,30 +10,55 @@ import java.util.Date;
 public class AccuAqiResult {
 
     /**
-     * Date : 2016-12-22T07:00:00+08:00
-     * EpochDate : 1482390000
-     * Index : 113
-     * ParticulateMatter2_5 : 85.0
-     * ParticulateMatter10 : 95.0
-     * Ozone : 23.0
-     * CarbonMonoxide : 0.9
-     * NitrogenMonoxide : null
-     * NitrogenDioxide : 40.0
-     * SulfurDioxide : 23.0
-     * Lead : null
-     * SettingsWeatherSource : Breezometer
+     * {
+     *   "success": true,
+     *   "status": "200",
+     *   "version": 2,
+     *   "data": [
+     *     {
+     *       "date": "2020-02-03T05:00:00+05:30",
+     *       "epochDate": 1580706000,
+     *       "overallIndex": 270.6,
+     *       "overallPlumeLabsIndex": 208.8,
+     *       "dominantPollutant": "Sulfure Dioxide",
+     *       "category": "Very Unhealthy",
+     *       "categoryColor": "#C72EAA",
+     *       "hazardStatement": "Health effects will be immediately felt by sensitive groups and should avoid outdoor activity. Healthy individuals are likely to experience difficulty breathing and throat irritation; consider staying indoors and rescheduling outdoor activities."
+     *       link": "https://www.accuweather.com/en/in/shyamapur/3182693/air-quality-index/3182693?lang=en-us
+     *     }
+     *     ]
+     * }
      */
 
-    public Date Date;
-    public long EpochDate;
-    public int Index;
-    public float ParticulateMatter2_5;
-    public float ParticulateMatter10;
-    public float Ozone;
-    public float CarbonMonoxide;
-    public float NitrogenMonoxide;
-    public float NitrogenDioxide;
-    public float SulfurDioxide;
-    public float Lead;
-    public String Source;
+    public boolean success;
+    public int status;
+    public int version;
+
+    public static class AqiData {
+        public Date date;
+        public long epochDate;
+        public int overallIndex;
+        public String dominantPollutant;
+        public String category;
+        public String categoryColor;
+        public String hazardStatement;
+
+        public static class Pollutant {
+            public String type;
+            public String name;
+
+            public static class Concentration {
+                public Float value;
+                public String unit;
+                public int unitType;
+            }
+
+            public Concentration concentration;
+            public String source;
+        }
+
+        public List<Pollutant> pollutants;
+    }
+
+    public List<AqiData> data;
 }

--- a/app/src/main/java/wangdaye/com/geometricweather/weather/services/AccuWeatherService.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/weather/services/AccuWeatherService.java
@@ -75,7 +75,8 @@ public class AccuWeatherService extends WeatherService {
 
         Observable<AccuAqiResult> aqi = mApi.getAirQuality(
                 location.getCityId(),
-                SettingsManager.getInstance(context).getProviderAccuAqiKey(true)
+                SettingsManager.getInstance(context).getProviderAccuAqiKey(true),
+                languageCode
         ).onExceptionResumeNext(
                 Observable.create(emitter -> emitter.onNext(new EmptyAqiResult()))
         );


### PR DESCRIPTION
Solves #277

I couldn't test it because the API returns the following response:
```
{
  "Code": "Unauthorized",
  "Message": "Api Authorization failed",
  "Reference": "/airquality/v2/forecasts/observations/226081?apikey=&details=true"
}
```

Should be noted that observations are only available with China and South Korea countries.