### PR TITLE
Create GitHub action to generate debug APKs at each commit

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,35 @@
+name: Geometric Weather CI
+
+on:
+  push:
+    branches: [ master, dev ]
+    paths-ignore:
+      - ".editorconfig"
+      - "fastlane/*"
+      - "release/*"
+      - "work/*"
+      - "LICENSE"
+      - "README.md"
+  pull_request:
+    branches: [ master, dev ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: gradle
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: app-debug.apk
+          path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
This will allow people to test upcoming features without having to set up an Android environment if they are not techy.

This must be merged on the `master` branch and will apply to master and dev branches + pull requests.