### PR TITLE
Add 'feels like' temperature option for persistent notification

### DIFF
--- a/app/src/main/java/wangdaye/com/geometricweather/remoteviews/presenters/notification/MultiCityNotificationIMP.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/remoteviews/presenters/notification/MultiCityNotificationIMP.java
@@ -87,6 +87,8 @@ public class MultiCityNotificationIMP extends AbstractRemoteViewsPresenter {
                 tempIcon ? ResourceHelper.getTempIconId(
                         context,
                         temperatureUnit.getValueWithoutUnit(
+                                SettingsManager.getInstance(context).isNotificationFeelsLike() ?
+                                weather.getCurrent().getTemperature().getRealFeelTemperature() :
                                 weather.getCurrent().getTemperature().getTemperature()
                         )
                 ) : ResourceHelper.getDefaultMinimalXmlIconId(
@@ -176,6 +178,8 @@ public class MultiCityNotificationIMP extends AbstractRemoteViewsPresenter {
                 R.id.notification_base_realtimeTemp,
                 Temperature.getShortTemperature(
                         context,
+                        SettingsManager.getInstance(context).isNotificationFeelsLike() ?
+                        weather.getCurrent().getTemperature().getRealFeelTemperature() :
                         weather.getCurrent().getTemperature().getTemperature(),
                         temperatureUnit
                 )

--- a/app/src/main/java/wangdaye/com/geometricweather/remoteviews/presenters/notification/NativeNormalNotificationIMP.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/remoteviews/presenters/notification/NativeNormalNotificationIMP.java
@@ -84,6 +84,8 @@ class NativeNormalNotificationIMP extends AbstractRemoteViewsPresenter {
                 tempIcon ? ResourceHelper.getTempIconId(
                         context,
                         temperatureUnit.getValueWithoutUnit(
+                                SettingsManager.getInstance(context).isNotificationFeelsLike() ?
+                                weather.getCurrent().getTemperature().getRealFeelTemperature() :
                                 weather.getCurrent().getTemperature().getTemperature()
                         )
                 ) : ResourceHelper.getDefaultMinimalXmlIconId(
@@ -116,7 +118,10 @@ class NativeNormalNotificationIMP extends AbstractRemoteViewsPresenter {
 
         StringBuilder content = new StringBuilder();
         if (!tempIcon) {
-            content.append(weather.getCurrent().getTemperature().getTemperature(context, temperatureUnit))
+            content.append(
+                    SettingsManager.getInstance(context).isNotificationFeelsLike() ?
+                    weather.getCurrent().getTemperature().getRealFeelTemperature(context, temperatureUnit) :
+                    weather.getCurrent().getTemperature().getTemperature(context, temperatureUnit))
                     .append(" ");
         }
         content.append(weather.getCurrent().getWeatherText());

--- a/app/src/main/java/wangdaye/com/geometricweather/remoteviews/presenters/notification/NormalNotificationIMP.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/remoteviews/presenters/notification/NormalNotificationIMP.java
@@ -118,6 +118,8 @@ public class NormalNotificationIMP extends AbstractRemoteViewsPresenter {
                 tempIcon ? ResourceHelper.getTempIconId(
                         context,
                         temperatureUnit.getValueWithoutUnit(
+                                settings.isNotificationFeelsLike() ?
+                                weather.getCurrent().getTemperature().getRealFeelTemperature() :
                                 weather.getCurrent().getTemperature().getTemperature()
                         )
                 ) : ResourceHelper.getDefaultMinimalXmlIconId(
@@ -192,6 +194,8 @@ public class NormalNotificationIMP extends AbstractRemoteViewsPresenter {
             return views;
         }
 
+        SettingsManager settings = SettingsManager.getInstance(context);
+
         views.setImageViewUri(
                 R.id.notification_base_icon,
                 ResourceHelper.getWidgetNotificationIconUri(
@@ -207,6 +211,8 @@ public class NormalNotificationIMP extends AbstractRemoteViewsPresenter {
                 R.id.notification_base_realtimeTemp,
                 Temperature.getShortTemperature(
                         context,
+                        settings.isNotificationFeelsLike() ?
+                        weather.getCurrent().getTemperature().getRealFeelTemperature() :
                         weather.getCurrent().getTemperature().getTemperature(),
                         temperatureUnit
                 )

--- a/app/src/main/java/wangdaye/com/geometricweather/settings/SettingsManager.kt
+++ b/app/src/main/java/wangdaye/com/geometricweather/settings/SettingsManager.kt
@@ -319,6 +319,13 @@ class SettingsManager private constructor(context: Context) {
 
     // notification.
 
+    var isNotificationFeelsLike: Boolean
+        set(value) {
+            config.edit().putBoolean("notification_feelslike", value).apply()
+            notifySettingsChanged()
+        }
+        get() = config.getBoolean("notification_feelslike", false)
+
     var isNotificationEnabled: Boolean
         set(value) {
             config.edit().putBoolean("notification_switch", value).apply()

--- a/app/src/main/java/wangdaye/com/geometricweather/settings/compose/RootSettingsScreen.kt
+++ b/app/src/main/java/wangdaye/com/geometricweather/settings/compose/RootSettingsScreen.kt
@@ -382,6 +382,23 @@ fun RootSettingsView(context: Context, navController: NavHostController) {
                 }
             )
         }
+        checkboxPreferenceItem(R.string.settings_title_notification_feels_like) { id ->
+            CheckboxPreferenceView(
+                titleId = id,
+                summaryOnId = R.string.on,
+                summaryOffId = R.string.off,
+                checked = SettingsManager
+                    .getInstance(context)
+                    .isNotificationFeelsLike,
+                enabled = notificationEnabledState.value,
+                onValueChanged = {
+                    SettingsManager
+                        .getInstance(context)
+                        .isNotificationFeelsLike = it
+                    PollingManager.resetNormalBackgroundTask(context, true)
+                }
+            )
+        }
         checkboxPreferenceItem(R.string.settings_title_notification_can_be_cleared) { id ->
             CheckboxPreferenceView(
                 titleId = id,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -291,7 +291,7 @@
 
     <string name="feedback_ignore_battery_optimizations_title">Ignore battery optimization</string>
     <string name="feedback_ignore_battery_optimizations_content">In order to ensure that the background services can continue to work, please ignore the battery optimization for GeometricWeather.</string>
-    
+
     <string name="feedback_cannot_start_live_wallpaper_activity">Unable to start live wallpaper preview context</string>
 
     <string name="feedback_unusable_geocoder">This device does not contain a valid geocoder. The location provider has been changed to Baidu Location.</string>
@@ -417,6 +417,7 @@
     <string name="settings_title_notification">Send Notification</string>
     <string name="settings_title_notification_style">Notification style</string>
     <string name="settings_title_notification_temp_icon">Temperature as status bar icon</string>
+    <string name="settings_title_notification_feels_like">Use Feels Like temperature</string>
     <string name="settings_title_notification_color">Notification color</string>
     <string name="settings_title_notification_custom_color">Custom Notification Color</string>
     <string name="settings_title_notification_text_color">Text color</string>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1109288/168342232-e682dd74-6fb7-4d05-bf5f-539a7d4747e0.png)
![image](https://user-images.githubusercontent.com/1109288/168342402-9740e151-4eef-494d-8999-430bd215c1a3.png)


I live in a very (variably) humid area, and usually when I glance at the temperature it's more an issue of whether I need to throw on a jacket or not. Feels Like temperature is more appropriate for this, as it can vary +/- 10 degrees from the actual temperature.

This change just lets you pick whether to use Feels Like or actual temperature in the notification (only for the live temp, not the forecast)