### PR TITLE
Add Gadgetbridge support: fix #237 

### DIFF
--- a/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/WeatherSpec.java
+++ b/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/WeatherSpec.java
@@ -1,0 +1,156 @@
+/*  Copyright (C) 2016-2020 Andreas Shimokawa, Carsten Pfeiffer, Daniele
+    Gobbetti
+
+    This file is part of Gadgetbridge.
+
+    Gadgetbridge is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Gadgetbridge is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package nodomain.freeyourgadget.gadgetbridge.model;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+// FIXME: document me and my fields, including units
+public class WeatherSpec implements Parcelable {
+    public static final Creator<WeatherSpec> CREATOR = new Creator<WeatherSpec>() {
+        @Override
+        public WeatherSpec createFromParcel(Parcel in) {
+            return new WeatherSpec(in);
+        }
+
+        @Override
+        public WeatherSpec[] newArray(int size) {
+            return new WeatherSpec[size];
+        }
+    };
+    public static final int VERSION = 2;
+    public int timestamp;
+    public String location;
+    public int currentTemp;
+    public int currentConditionCode = 3200;
+    public String currentCondition;
+    public int currentHumidity;
+    public int todayMaxTemp;
+    public int todayMinTemp;
+    public float windSpeed; //km per hour
+    public int windDirection; //deg
+
+    public ArrayList<Forecast> forecasts = new ArrayList<>();
+
+    public WeatherSpec() {
+
+    }
+
+    // Lower bounds of beaufort regions 1 to 12
+    // Values from https://en.wikipedia.org/wiki/Beaufort_scale
+    static final float[] beaufort = new float[] { 2, 6, 12, 20, 29, 39, 50, 62, 75, 89, 103, 118 };
+    //                                    level: 0 1  2   3   4   5   6   7   8   9   10   11   12
+
+    public int windSpeedAsBeaufort() {
+        int l = 0;
+        while (l < beaufort.length && beaufort[l] < this.windSpeed) {
+            l++;
+        }
+        return l;
+    }
+
+    protected WeatherSpec(Parcel in) {
+        int version = in.readInt();
+        if (version == VERSION) {
+            timestamp = in.readInt();
+            location = in.readString();
+            currentTemp = in.readInt();
+            currentConditionCode = in.readInt();
+            currentCondition = in.readString();
+            currentHumidity = in.readInt();
+            todayMaxTemp = in.readInt();
+            todayMinTemp = in.readInt();
+            windSpeed = in.readFloat();
+            windDirection = in.readInt();
+            in.readList(forecasts, Forecast.class.getClassLoader());
+        }
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeInt(VERSION);
+        dest.writeInt(timestamp);
+        dest.writeString(location);
+        dest.writeInt(currentTemp);
+        dest.writeInt(currentConditionCode);
+        dest.writeString(currentCondition);
+        dest.writeInt(currentHumidity);
+        dest.writeInt(todayMaxTemp);
+        dest.writeInt(todayMinTemp);
+        dest.writeFloat(windSpeed);
+        dest.writeInt(windDirection);
+        dest.writeList(forecasts);
+    }
+
+    public static class Forecast implements Parcelable {
+        public static final Creator<Forecast> CREATOR = new Creator<Forecast>() {
+            @Override
+            public Forecast createFromParcel(Parcel in) {
+                return new Forecast(in);
+            }
+
+            @Override
+            public Forecast[] newArray(int size) {
+                return new Forecast[size];
+            }
+        };
+        public int minTemp;
+        public int maxTemp;
+        public int conditionCode;
+        public int humidity;
+
+        public Forecast() {
+        }
+
+        public Forecast(int minTemp, int maxTemp, int conditionCode, int humidity) {
+            this.minTemp = minTemp;
+            this.maxTemp = maxTemp;
+            this.conditionCode = conditionCode;
+            this.humidity = humidity;
+        }
+
+        Forecast(Parcel in) {
+            minTemp = in.readInt();
+            maxTemp = in.readInt();
+            conditionCode = in.readInt();
+            humidity = in.readInt();
+        }
+
+        @Override
+        public int describeContents() {
+            return 0;
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            dest.writeInt(minTemp);
+            dest.writeInt(maxTemp);
+            dest.writeInt(conditionCode);
+            dest.writeInt(humidity);
+        }
+    }
+}

--- a/app/src/main/java/wangdaye/com/geometricweather/gadgetbridge/GadgetbridgeAPI.kt
+++ b/app/src/main/java/wangdaye/com/geometricweather/gadgetbridge/GadgetbridgeAPI.kt
@@ -1,0 +1,109 @@
+package wangdaye.com.geometricweather.gadgetbridge
+
+import android.content.Context
+import android.content.Intent
+import nodomain.freeyourgadget.gadgetbridge.model.WeatherSpec
+import wangdaye.com.geometricweather.common.basic.models.Location
+import wangdaye.com.geometricweather.common.basic.models.weather.Weather
+import wangdaye.com.geometricweather.common.basic.models.weather.WeatherCode
+import wangdaye.com.geometricweather.settings.SettingsManager
+
+object GadgetbridgeAPI {
+    const val WEATHER_EXTRA = "WeatherSpec"
+    const val WEATHER_ACTION = "de.kaffeemitkoffein.broadcast.WEATHERDATA"
+    const val GADGETBRIDGE_PACKAGE_NAME = "nodomain.freeyourgadget.gadgetbridge"
+
+    @JvmStatic
+    fun sendWeatherBroadcast(context: Context, location: Location) {
+        val weatherSpec = location.weather?.translateToGadgetbridgeWeatherSpec() ?: return
+        weatherSpec.location = location.city
+        val intent = Intent()
+        intent.putExtra(WEATHER_EXTRA, weatherSpec)
+        intent.setPackage(GADGETBRIDGE_PACKAGE_NAME)
+        intent.flags = Intent.FLAG_INCLUDE_STOPPED_PACKAGES
+        intent.action = WEATHER_ACTION
+        context.sendBroadcast(intent)
+    }
+
+    @JvmStatic
+    fun isEnabled(context: Context): Boolean {
+        return SettingsManager.getInstance(context).isGadgetbridgeSupportEnabled
+    }
+}
+
+private fun Weather.translateToGadgetbridgeWeatherSpec(): WeatherSpec {
+    val weatherSpec = WeatherSpec()
+    val weather = this
+
+    weatherSpec.timestamp = (weather.base.updateTime / 1000).toInt()
+    weatherSpec.currentConditionCode = weather.current.weatherCode.translateToOpenWeatherCode()
+    weatherSpec.currentCondition = weather.current.weatherCode.name
+    weatherSpec.currentTemp = weather.current.temperature.temperature.translateTemp()
+    weather.current.relativeHumidity?.let { weatherSpec.currentHumidity = it.toInt() }
+    weatherSpec.todayMaxTemp =
+        weather.dailyForecast[0].day().temperature.temperature.translateTemp()
+    weatherSpec.todayMinTemp =
+        weather.dailyForecast[0].night().temperature.temperature.translateTemp()
+    weatherSpec.windDirection = weather.current.wind.degree.degree.toInt()
+    weather.current.wind.speed?.let { weatherSpec.windSpeed = it }
+
+    weather.dailyForecast
+        .filterIndexed { index, daily -> index != 0 }
+        .forEach { daily ->
+            weatherSpec.forecasts.add(WeatherSpec.Forecast().apply {
+                this.conditionCode = daily.day().weatherCode.translateToOpenWeatherCode()
+                this.maxTemp = daily.day().temperature.temperature.translateTemp()
+                this.minTemp = daily.night().temperature.temperature.translateTemp()
+            })
+        }
+    return weatherSpec
+}
+
+
+private fun WeatherCode.translateToOpenWeatherCode(): Int {
+    return when (this) {
+        WeatherCode.CLEAR -> {
+            OpenWeatherContract.CLEAR_SKY
+        }
+        WeatherCode.PARTLY_CLOUDY -> {
+            OpenWeatherContract.FEW_CLOUDS
+        }
+        WeatherCode.CLOUDY -> {
+            OpenWeatherContract.OVERCAST_CLOUDS
+        }
+        WeatherCode.RAIN -> {
+            OpenWeatherContract.MODERATE_RAIN
+        }
+        WeatherCode.SNOW -> {
+            OpenWeatherContract.SNOW
+        }
+        WeatherCode.WIND -> {
+            OpenWeatherContract.WINDY
+        }
+        WeatherCode.FOG -> {
+            OpenWeatherContract.FOG
+        }
+        WeatherCode.HAZE -> {
+            OpenWeatherContract.HAZE
+        }
+        WeatherCode.SLEET -> {
+            OpenWeatherContract.SLEET
+        }
+        WeatherCode.HAIL -> {
+            OpenWeatherContract.HAIL
+        }
+        WeatherCode.THUNDER -> {
+            OpenWeatherContract.THUNDERSTORM
+        }
+        WeatherCode.THUNDERSTORM -> {
+            OpenWeatherContract.THUNDERSTORM
+        }
+        else -> {
+            OpenWeatherContract.UNKNOWN
+        }
+    }
+}
+
+private fun Int.translateTemp(): Int {
+    return this + 17
+}

--- a/app/src/main/java/wangdaye/com/geometricweather/gadgetbridge/OpenWeatherContract.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/gadgetbridge/OpenWeatherContract.java
@@ -1,0 +1,33 @@
+package wangdaye.com.geometricweather.gadgetbridge;
+
+public final class OpenWeatherContract {
+    public final static int THUNDERSTORM = 211;
+    public final static int FREEZING_RAIN = 511;
+    public final static int HEAVY_SHOWER_SNOW = 622;
+    public final static int LIGHT_SHOWER_SNOW = 620;
+    public final static int RAIN_AND_SNOW = 616;
+    public final static int LIGHT_RAIN_AND_SNOW = 615;
+    public final static int HEAVY_INTENSITY_SHOWER_RAIN = 522;
+    public final static int EXTREME_RAIN = 504;
+    public final static int LIGHT_INTENSITY_SHOWER_RAIN = 520;
+    public final static int SLEET = 611;
+    public final static int HEAVY_SNOW = 602;
+    public final static int SNOW = 601;
+    public final static int LIGHT_SNOW = 600;
+    public final static int HEAVY_INTENSITY_DRIZZE = 302;
+    public final static int DRIZZLE = 301;
+    public final static int LIGHT_INTENSITY_DRIZZLE = 300;
+    public final static int HEAVY_INTENSITY_RAIN = 502;
+    public final static int MODERATE_RAIN = 501;
+    public final static int LIGHT_RAIN = 500;
+    public final static int HAZE = 721;
+    public final static int FOG = 741;
+    public final static int OVERCAST_CLOUDS = 804;
+    public final static int BROKEN_CLOUDS = 803;
+    public final static int SCATTERED_CLOUDS = 802;
+    public final static int FEW_CLOUDS = 801;
+    public final static int CLEAR_SKY = 800;
+    public final static int WINDY = 905;
+    public final static int HAIL = 906;
+    public final static int UNKNOWN = 3200;
+}

--- a/app/src/main/java/wangdaye/com/geometricweather/remoteviews/WidgetHelper.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/remoteviews/WidgetHelper.java
@@ -11,6 +11,7 @@ import wangdaye.com.geometricweather.R;
 import wangdaye.com.geometricweather.common.basic.models.Location;
 import wangdaye.com.geometricweather.common.basic.models.options.unit.TemperatureUnit;
 import wangdaye.com.geometricweather.common.basic.models.weather.Weather;
+import wangdaye.com.geometricweather.gadgetbridge.GadgetbridgeAPI;
 import wangdaye.com.geometricweather.remoteviews.presenters.AndroidSWidgetIMP;
 import wangdaye.com.geometricweather.remoteviews.presenters.ClockDayDetailsWidgetIMP;
 import wangdaye.com.geometricweather.remoteviews.presenters.ClockDayHorizontalWidgetIMP;
@@ -27,6 +28,9 @@ import wangdaye.com.geometricweather.remoteviews.presenters.WeekWidgetIMP;
 public class WidgetHelper {
 
     public static void updateWidgetIfNecessary(Context context, Location location) {
+        if (GadgetbridgeAPI.isEnabled(context)) {
+            GadgetbridgeAPI.sendWeatherBroadcast(context, location);
+        }
         if (DayWidgetIMP.isEnable(context)) {
             DayWidgetIMP.updateWidgetView(context, location);
         }

--- a/app/src/main/java/wangdaye/com/geometricweather/settings/SettingsManager.kt
+++ b/app/src/main/java/wangdaye/com/geometricweather/settings/SettingsManager.kt
@@ -349,6 +349,15 @@ class SettingsManager private constructor(context: Context) {
         }
         get() = config.getBoolean("notification_can_clear_switch", false)
 
+    // Gadgetbridge.
+
+    var isGadgetbridgeSupportEnabled: Boolean
+        set(value) {
+            config.edit().putBoolean("gadgetbridge_support_switch", value).apply()
+            notifySettingsChanged()
+        }
+        get() = config.getBoolean("gadgetbridge_support_switch", false)
+
     // service provider advanced.
 
     var customAccuWeatherKey: String

--- a/app/src/main/java/wangdaye/com/geometricweather/settings/compose/RootSettingsScreen.kt
+++ b/app/src/main/java/wangdaye/com/geometricweather/settings/compose/RootSettingsScreen.kt
@@ -401,6 +401,26 @@ fun RootSettingsView(context: Context, navController: NavHostController) {
         }
         sectionFooterItem(R.string.settings_category_notification)
 
+        // Gadgetbridge.
+        sectionHeaderItem(R.string.settings_category_gadgetbridge_support)
+        checkboxPreferenceItem(R.string.settings_title_gadgetbridge_support_enable) { id ->
+            CheckboxPreferenceView(
+                titleId = id,
+                summaryOnId = R.string.on,
+                summaryOffId = R.string.off,
+                checked = SettingsManager
+                    .getInstance(context)
+                    .isGadgetbridgeSupportEnabled,
+                onValueChanged = {
+                    SettingsManager
+                        .getInstance(context)
+                        .isGadgetbridgeSupportEnabled = it
+                    PollingManager.resetNormalBackgroundTask(context, true)
+                }
+            )
+        }
+        sectionFooterItem(R.string.settings_category_gadgetbridge_support)
+
         bottomInsetItem()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -434,6 +434,8 @@
     <string name="settings_title_notification_hide_big_view">Extended style</string>
     <string name="settings_notification_hide_big_view_on">Hide</string>
     <string name="settings_notification_hide_big_view_off">Show</string>
+    <string name="settings_category_gadgetbridge_support">Gadgetbridge support</string>
+    <string name="settings_title_gadgetbridge_support_enable">Enable gadgetbridge support</string>
     <string name="settings_provider_default_value">Default (unchanged)</string>
     <string name="settings_provider_accu_weather">AccuWeather</string>
     <string name="settings_provider_accu_weather_key">AccuWeather weather key</string>


### PR DESCRIPTION
Fix #237 
Gadgetbridge is an Android (4.4+) application which will allow you to use your Pebble, Mi Band, Amazfit Bip and HPlus device (and more) without the vendor's closed source application and without the need to create an account and transmit any of your data to the vendor's servers.
Gadgetbridge offers support for forwarding weather information to the band/watch and it needs the help of a weather provider. This PR makes GeometricWeather a weather provider.