### PR TITLE
Handle "Too many requests" status code and inform user they can add their own API key

### DIFF
--- a/app/src/main/java/wangdaye/com/geometricweather/background/interfaces/CMWeatherProviderService.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/background/interfaces/CMWeatherProviderService.java
@@ -204,12 +204,12 @@ public class CMWeatherProviderService extends WeatherProviderService
                 mRequest.complete(new ServiceRequestResult.Builder(builder.build()).build());
             }
         } catch (Exception ignore) {
-            requestWeatherFailed(requestLocation);
+            requestWeatherFailed(requestLocation, false);
         }
     }
 
     @Override
-    public void requestWeatherFailed(@NonNull Location requestLocation) {
+    public void requestWeatherFailed(@NonNull Location requestLocation, @NonNull Boolean apiLimitReached) {
         if (mRequest != null) {
             mRequest.fail();
         }

--- a/app/src/main/java/wangdaye/com/geometricweather/background/polling/PollingUpdateHelper.kt
+++ b/app/src/main/java/wangdaye/com/geometricweather/background/polling/PollingUpdateHelper.kt
@@ -119,7 +119,7 @@ class PollingUpdateHelper(
             if (locationList[index].isUsable) {
                 requestData(index, true)
             } else {
-                RequestWeatherCallback(index, total).requestWeatherFailed(locationList[index])
+                RequestWeatherCallback(index, total).requestWeatherFailed(locationList[index], false)
             }
         }
     }
@@ -146,11 +146,11 @@ class PollingUpdateHelper(
 
                 checkToRequestNextOrCompleted()
             } else {
-                requestWeatherFailed(requestLocation)
+                requestWeatherFailed(requestLocation, false)
             }
         }
 
-        override fun requestWeatherFailed(requestLocation: Location) {
+        override fun requestWeatherFailed(requestLocation: Location, apiLimitReached: Boolean) {
             val old = locationList[index].weather
             locationList[index] = requestLocation
 

--- a/app/src/main/java/wangdaye/com/geometricweather/common/rxjava/BaseObserver.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/common/rxjava/BaseObserver.java
@@ -1,12 +1,23 @@
 package wangdaye.com.geometricweather.common.rxjava;
 
 import io.reactivex.observers.DisposableObserver;
+import retrofit2.HttpException;
 
 public abstract class BaseObserver<T> extends DisposableObserver<T> {
+
+    protected Integer code;
 
     public abstract void onSucceed(T t);
 
     public abstract void onFailed();
+
+    public Integer getStatusCode() {
+        return code;
+    }
+
+    public Boolean isApiLimitReached() {
+        return code == 429;
+    }
 
     @Override
     public void onNext(T t) {
@@ -19,6 +30,7 @@ public abstract class BaseObserver<T> extends DisposableObserver<T> {
 
     @Override
     public void onError(Throwable e) {
+        this.code = ((HttpException) e).code();
         onFailed();
     }
 

--- a/app/src/main/java/wangdaye/com/geometricweather/main/MainActivity.kt
+++ b/app/src/main/java/wangdaye/com/geometricweather/main/MainActivity.kt
@@ -28,6 +28,7 @@ import wangdaye.com.geometricweather.common.utils.helpers.IntentHelper
 import wangdaye.com.geometricweather.common.utils.helpers.ShortcutsHelper
 import wangdaye.com.geometricweather.common.utils.helpers.SnackbarHelper
 import wangdaye.com.geometricweather.databinding.ActivityMainBinding
+import wangdaye.com.geometricweather.main.dialogs.ApiKeyHelpDialog
 import wangdaye.com.geometricweather.main.dialogs.LocationHelpDialog
 import wangdaye.com.geometricweather.main.fragments.HomeFragment
 import wangdaye.com.geometricweather.main.fragments.ManagementFragment
@@ -289,6 +290,14 @@ class MainActivity : GeoActivity(),
                         SnackbarHelper.showSnackbar(
                             getString(R.string.feedback_get_weather_failed)
                         )
+                    }
+                    MainMessage.API_LIMIT_REACHED -> {
+                        SnackbarHelper.showSnackbar(
+                            getString(R.string.feedback_api_limit_reached),
+                            getString(R.string.help)
+                        ) {
+                            ApiKeyHelpDialog.show(this)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/wangdaye/com/geometricweather/main/MainActivityModels.kt
+++ b/app/src/main/java/wangdaye/com/geometricweather/main/MainActivityModels.kt
@@ -60,6 +60,7 @@ class SelectableLocationList(
 enum class MainMessage {
     LOCATION_FAILED,
     WEATHER_REQ_FAILED,
+    API_LIMIT_REACHED,
 }
 
 class DayNightLocation(

--- a/app/src/main/java/wangdaye/com/geometricweather/main/MainActivityRepository.kt
+++ b/app/src/main/java/wangdaye/com/geometricweather/main/MainActivityRepository.kt
@@ -20,7 +20,8 @@ class MainActivityRepository @Inject constructor(
         fun onCompleted(
             location: Location,
             locationFailed: Boolean?,
-            weatherRequestFailed: Boolean
+            weatherRequestFailed: Boolean,
+            apiLimitReached: Boolean
         )
     }
 
@@ -147,18 +148,20 @@ class MainActivityRepository @Inject constructor(
                 callback.onCompleted(
                     requestLocation,
                     locationFailed = locationFailed,
-                    weatherRequestFailed = false
+                    weatherRequestFailed = false,
+                    apiLimitReached = false
                 )
             }
 
-            override fun requestWeatherFailed(requestLocation: Location) {
+            override fun requestWeatherFailed(requestLocation: Location, apiLimitReached: Boolean) {
                 if (requestLocation.formattedId != location.formattedId) {
                     return
                 }
                 callback.onCompleted(
                     requestLocation,
                     locationFailed = locationFailed,
-                    weatherRequestFailed = true
+                    weatherRequestFailed = true,
+                    apiLimitReached = apiLimitReached
                 )
             }
         }

--- a/app/src/main/java/wangdaye/com/geometricweather/main/MainActivityViewModel.kt
+++ b/app/src/main/java/wangdaye/com/geometricweather/main/MainActivityViewModel.kt
@@ -165,8 +165,11 @@ class MainActivityViewModel @Inject constructor(
         location: Location,
         locationResult: Boolean,
         weatherUpdateResult: Boolean,
+        apiLimitReached: Boolean,
     ) {
-        if (!weatherUpdateResult) {
+        if (apiLimitReached) {
+            mainMessage.setValue(MainMessage.API_LIMIT_REACHED)
+        } else if (!weatherUpdateResult) {
             mainMessage.setValue(MainMessage.WEATHER_REQ_FAILED)
         } else if (!locationResult) {
             mainMessage.setValue(MainMessage.LOCATION_FAILED)
@@ -466,12 +469,14 @@ class MainActivityViewModel @Inject constructor(
     override fun onCompleted(
         location: Location,
         locationFailed: Boolean?,
-        weatherRequestFailed: Boolean
+        weatherRequestFailed: Boolean,
+        apiLimitReached: Boolean,
     ) {
         onUpdateResult(
             location = location,
             locationResult = locationFailed != true,
-            weatherUpdateResult = !weatherRequestFailed
+            weatherUpdateResult = !weatherRequestFailed,
+            apiLimitReached = apiLimitReached
         )
     }
 }

--- a/app/src/main/java/wangdaye/com/geometricweather/main/dialogs/ApiKeyHelpDialog.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/main/dialogs/ApiKeyHelpDialog.java
@@ -1,0 +1,36 @@
+package wangdaye.com.geometricweather.main.dialogs;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.view.LayoutInflater;
+import android.view.View;
+
+import androidx.appcompat.app.AlertDialog;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import wangdaye.com.geometricweather.R;
+import wangdaye.com.geometricweather.common.utils.helpers.IntentHelper;
+
+public class ApiKeyHelpDialog {
+
+    public static void show(Activity activity) {
+        View view = LayoutInflater
+                .from(activity)
+                .inflate(R.layout.dialog_api_help, null, false);
+        initWidget(
+                activity,
+                view,
+                new MaterialAlertDialogBuilder(activity)
+                        .setTitle(R.string.feedback_api_help_title)
+                        .setView(view)
+                        .show()
+        );
+    }
+
+    @SuppressLint("SetTextI18n")
+    private static void initWidget(Activity activity, View view, AlertDialog dialog) {
+        view.findViewById(R.id.dialog_location_help_providerContainer)
+                .setOnClickListener(v -> IntentHelper.startSelectProviderActivity(activity));
+    }
+}

--- a/app/src/main/java/wangdaye/com/geometricweather/remoteviews/config/AbstractWidgetConfigActivity.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/remoteviews/config/AbstractWidgetConfigActivity.java
@@ -593,14 +593,14 @@ public abstract class AbstractWidgetConfigActivity extends GeoActivity
 
         locationNow = requestLocation;
         if (requestLocation.getWeather() == null) {
-            requestWeatherFailed(requestLocation);
+            requestWeatherFailed(requestLocation, false);
         } else {
             updateHostView();
         }
     }
 
     @Override
-    public void requestWeatherFailed(@NonNull Location requestLocation) {
+    public void requestWeatherFailed(@NonNull Location requestLocation, @NonNull Boolean apiLimitReached) {
         if (destroyed) {
             return;
         }

--- a/app/src/main/java/wangdaye/com/geometricweather/weather/WeatherHelper.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/weather/WeatherHelper.java
@@ -29,7 +29,7 @@ public class WeatherHelper {
 
     public interface OnRequestWeatherListener {
         void requestWeatherSuccess(@NonNull Location requestLocation);
-        void requestWeatherFailed(@NonNull Location requestLocation);
+        void requestWeatherFailed(@NonNull Location requestLocation, @NonNull Boolean apiLimitReached);
     }
 
     public interface OnRequestLocationListener {
@@ -47,7 +47,7 @@ public class WeatherHelper {
     public void requestWeather(Context c, Location location, @NonNull final OnRequestWeatherListener l) {
         final WeatherService service = mServiceSet.get(location.getWeatherSource());
         if (!NetworkUtils.isAvailable(c)) {
-            l.requestWeatherFailed(location);
+            l.requestWeatherFailed(location, false);
             return;
         }
 
@@ -65,17 +65,18 @@ public class WeatherHelper {
                     }
                     l.requestWeatherSuccess(requestLocation);
                 } else {
-                    requestWeatherFailed(requestLocation);
+                    requestWeatherFailed(requestLocation, false);
                 }
             }
 
             @Override
-            public void requestWeatherFailed(@NonNull Location requestLocation) {
+            public void requestWeatherFailed(@NonNull Location requestLocation, @NonNull Boolean apiLimitReached) {
                 l.requestWeatherFailed(
                         Location.copy(
                                 requestLocation,
                                 DatabaseHelper.getInstance(c).readWeather(requestLocation)
-                        )
+                        ),
+                        apiLimitReached
                 );
             }
         });

--- a/app/src/main/java/wangdaye/com/geometricweather/weather/services/AccuWeatherService.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/weather/services/AccuWeatherService.java
@@ -109,7 +109,7 @@ public class AccuWeatherService extends WeatherService {
 
                     @Override
                     public void onFailed() {
-                        callback.requestWeatherFailed(location);
+                        callback.requestWeatherFailed(location, this.isApiLimitReached());
                     }
                 }));
     }

--- a/app/src/main/java/wangdaye/com/geometricweather/weather/services/CaiYunWeatherService.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/weather/services/CaiYunWeatherService.java
@@ -75,13 +75,13 @@ public class CaiYunWeatherService extends WeatherService {
                                     Location.copy(location, wrapper.result)
                             );
                         } else {
-                            callback.requestWeatherFailed(location);
+                            onFailed();
                         }
                     }
 
                     @Override
                     public void onFailed() {
-                        callback.requestWeatherFailed(location);
+                        callback.requestWeatherFailed(location, this.isApiLimitReached());
                     }
                 }));
     }

--- a/app/src/main/java/wangdaye/com/geometricweather/weather/services/MfWeatherService.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/weather/services/MfWeatherService.java
@@ -126,7 +126,7 @@ public class MfWeatherService extends WeatherService {
 
                     @Override
                     public void onFailed() {
-                        callback.requestWeatherFailed(location);
+                        callback.requestWeatherFailed(location, this.isApiLimitReached());
                     }
                 }));
     }

--- a/app/src/main/java/wangdaye/com/geometricweather/weather/services/OwmWeatherService.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/weather/services/OwmWeatherService.java
@@ -83,7 +83,7 @@ public class OwmWeatherService extends WeatherService {
 
                     @Override
                     public void onFailed() {
-                        callback.requestWeatherFailed(location);
+                        callback.requestWeatherFailed(location, this.isApiLimitReached());
                     }
                 }));
     }

--- a/app/src/main/java/wangdaye/com/geometricweather/weather/services/WeatherService.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/weather/services/WeatherService.java
@@ -29,7 +29,7 @@ public abstract class WeatherService {
 
     public interface RequestWeatherCallback {
         void requestWeatherSuccess(@NonNull Location requestLocation);
-        void requestWeatherFailed(@NonNull Location requestLocation);
+        void requestWeatherFailed(@NonNull Location requestLocation, @NonNull Boolean apiLimitReached);
     }
 
     public interface RequestLocationCallback {

--- a/app/src/main/res/layout/dialog_api_help.xml
+++ b/app/src/main/res/layout/dialog_api_help.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/dialog_api_help_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingTop="@dimen/normal_margin">
+
+    <RelativeLayout
+        android:id="@+id/dialog_location_help_providerContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:foreground="@drawable/selectable_item_background"
+        tools:ignore="UnusedAttribute">
+
+        <ImageView
+            android:id="@+id/dialog_api_help_keyIcon"
+            android:src="@drawable/ic_router"
+            android:layout_centerVertical="true"
+            style="@style/material_icon"
+            tools:ignore="ContentDescription"
+            app:tint="#607d8b" />
+
+        <TextView
+            android:id="@+id/dialog_api_help_keyTitle"
+            android:text="@string/feedback_add_api_key"
+            android:layout_marginTop="@dimen/normal_margin"
+            android:layout_marginBottom="@dimen/normal_margin"
+            android:layout_marginEnd="@dimen/normal_margin"
+            android:layout_centerVertical="true"
+            android:layout_toEndOf="@id/dialog_api_help_keyIcon"
+            style="@style/content_text" />
+
+    </RelativeLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -172,6 +172,9 @@
     <string name="feedback_enable_location_information">Activez les informations de localisation</string>
     <string name="feedback_select_location_provider">Sélectionnez un fournisseur de localisation</string>
     <string name="feedback_add_location_manually">Ajoutez manuellement la localisation et supprimez \'$\'</string>
+    <string name="feedback_api_limit_reached">Limite de requêtes API atteinte</string>
+    <string name="feedback_api_help_title">Limite de requêtes API atteinte ?</string>
+    <string name="feedback_add_api_key">Pour contourner la limite, ajoutez votre propre clé API.</string>
     <string name="feedback_view_style">Apparence</string>
     <string name="feedback_show_widget_card">Couleur d’arrière-plan</string>
     <string name="feedback_show_widget_card_alpha">Transparence</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -199,6 +199,9 @@
     <string name="feedback_enable_location_information">Enable Location Information</string>
     <string name="feedback_select_location_provider">Select Location Provider</string>
     <string name="feedback_add_location_manually">Add Location Manually And Delete \'$\'</string>
+    <string name="feedback_api_limit_reached">API requests limit reached</string>
+    <string name="feedback_api_help_title">API requests limit reached?</string>
+    <string name="feedback_add_api_key">To workaround the limit, add your own API key.</string>
     <string name="feedback_view_style">View style</string>
     <string name="feedback_show_widget_card">Background color</string>
     <string name="feedback_show_widget_card_alpha">Transparency</string>

--- a/work/deprecated/FWeather.java
+++ b/work/deprecated/FWeather.java
@@ -32,7 +32,7 @@ public class FWeather {
                     if (response.isSuccessful() && response.body() != null) {
                         l.requestWeatherSuccess(Weather.buildWeather(response.body()), location);
                     } else {
-                        l.requestWeatherFailed(location);
+                        l.requestWeatherFailed(location, false);
                     }
                 }
             }
@@ -40,7 +40,7 @@ public class FWeather {
             @Override
             public void onFailure(Call<FWResult> call, Throwable t) {
                 if (l != null) {
-                    l.requestWeatherFailed(location);
+                    l.requestWeatherFailed(location, false);
                 }
             }
         });

--- a/work/deprecated/HefengWeather.java
+++ b/work/deprecated/HefengWeather.java
@@ -42,7 +42,7 @@ public class HefengWeather {
                     if (response.isSuccessful() && response.body() != null) {
                         l.requestWeatherSuccess(Weather.buildWeather(oldResult, response.body()), location);
                     } else {
-                        l.requestWeatherFailed(location);
+                        l.requestWeatherFailed(location, false);
                     }
                 }
             }
@@ -50,7 +50,7 @@ public class HefengWeather {
             @Override
             public void onFailure(Call<HefengResult> call, Throwable t) {
                 if (l != null) {
-                    l.requestWeatherFailed(location);
+                    l.requestWeatherFailed(location, false);
                 }
             }
         });


### PR DESCRIPTION
New features:
- Add status code handling in the Observer
- If status code is 429, add a toast message
- If the user clicks on "HELP" button, a dialog is opened and inform the user they can add their own API key. If the user click on the message, this will open the Service provider settings.

Possible improvements:
- Before telling the user to add their API key, add a message "Instructions to get a personal API key". By clicking on it, this would open a wiki page on this GitHub telling him how to proceed for each provider.
- I didn't know how to proceed with the PollingUpdateHelper, so the API limit toast message never shows up. However, I thing Polling Updater is what runs in the background, so there is never a toast message anyway, right?
- Currently, this doesn't seem to inform the user of API limit reached on the location search side (only on weather data fetch), as I couldn't find where it was done
- Instead of opening "Service provider settings", we could open directly "Advanced provider settings", but it would require adding a few classes.
- This code could serve as a base for #244. However, I'm currently getting the status code from the HttpException and not from the Response itself (which would require heavier refactoring).