### PR TITLE
Display current UV for Météo France results

### DIFF
--- a/app/src/main/java/wangdaye/com/geometricweather/weather/converters/CommonConverter.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/weather/converters/CommonConverter.java
@@ -10,6 +10,7 @@ import java.util.Date;
 
 import wangdaye.com.geometricweather.R;
 import wangdaye.com.geometricweather.common.basic.models.weather.AirQuality;
+import wangdaye.com.geometricweather.common.basic.models.weather.UV;
 import wangdaye.com.geometricweather.common.basic.models.weather.Wind;
 
 public class CommonConverter {
@@ -121,5 +122,28 @@ public class CommonConverter {
         int currentTime = calendar.get(Calendar.HOUR_OF_DAY) * 60 + calendar.get(Calendar.MINUTE);
 
         return sunriseTime < currentTime && currentTime < sunsetTime;
+    }
+
+    public static UV getCurrentUV(int dayMaxUV, Date currentDate, Date sunriseDate, Date sunsetDate) {
+        if (currentDate == null || sunriseDate == null || sunsetDate == null || sunriseDate.after(sunsetDate))
+            return new UV(null, null, null);
+
+        // You can visualize formula here: https://www.desmos.com/calculator/lna7dco4zi
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(currentDate);
+        float currentTime = calendar.get(Calendar.HOUR_OF_DAY) + calendar.get(Calendar.MINUTE) / 60f; // Approximating to the minute is enough
+
+        calendar.setTime(sunriseDate);
+        float sunRiseTime = calendar.get(Calendar.HOUR_OF_DAY) + calendar.get(Calendar.MINUTE) / 60f; // b in desmos graph
+
+        calendar.setTime(sunsetDate);
+        float sunSetTime = calendar.get(Calendar.HOUR_OF_DAY) + calendar.get(Calendar.MINUTE) / 60f; // c in desmos graph
+
+        float sunlightDuration = sunSetTime - sunRiseTime; // d in desmos graph
+
+        float sunRiseOffset = (float) -Math.PI * sunRiseTime / sunlightDuration; // o in desmos graph
+        double currentUV = dayMaxUV * Math.sin(Math.PI / sunlightDuration * currentTime + sunRiseOffset); // dayMaxUV = a in desmos graph
+
+        return new UV(Math.toIntExact(Math.round(currentUV)), null, null);
     }
 }

--- a/app/src/main/java/wangdaye/com/geometricweather/weather/converters/MfResultConverter.java
+++ b/app/src/main/java/wangdaye/com/geometricweather/weather/converters/MfResultConverter.java
@@ -206,7 +206,7 @@ public class MfResultConverter {
                                     currentResult.observation.wind.speed * 3.6f,
                                     CommonConverter.getWindLevel(context, currentResult.observation.wind.speed * 3.6f)
                             ),
-                            new UV(null, null, null),
+                            getCurrentUV(new Date(), forecastResult.dailyForecasts),
                             getAirQuality(new Date(), aqiAtmoAuraResult),
                             null,
                             null,
@@ -459,6 +459,17 @@ public class MfResultConverter {
             return snow.cumul24H;
         }
         return null;
+    }
+
+    private static UV getCurrentUV(Date currentDate, List<MfForecastResult.DailyForecast> dailyForecasts) {
+        if (dailyForecasts == null || dailyForecasts.isEmpty())
+            return new UV(null, null, null);
+
+        MfForecastResult.DailyForecast todayForecast = dailyForecasts.get(0);
+        if (todayForecast == null || todayForecast.sun.rise == null || todayForecast.sun.set == null)
+            return new UV(null, null, null);
+
+        return CommonConverter.getCurrentUV(todayForecast.uv, currentDate, new Date(todayForecast.sun.rise * 1000), new Date(todayForecast.sun.set * 1000));
     }
 
     private static Precipitation getHourlyPrecipitation(MfForecastResult.Forecast hourlyForecast) {


### PR DESCRIPTION
Hello,

Météo France (and I guess probably other providers) just gives the maximum UV value during the day. I've added CommonConverter.getCurrentUV to get the UV at a given time, based on that value. Then I've used this helper method for Météo France results, but it can be used for other providers as well (as long as you know the time of the sunrise and sunset)

This is my first contribution to an Android app, so please don't hesitate to let me know if there are changes you'd like to see for it to be merged!