### PR TITLE
Add cache support for OkHttpClient

### DIFF
--- a/app/src/main/java/wangdaye/com/geometricweather/GeometricWeather.kt
+++ b/app/src/main/java/wangdaye/com/geometricweather/GeometricWeather.kt
@@ -3,12 +3,14 @@ package wangdaye.com.geometricweather
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.os.Process
+import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.multidex.MultiDexApplication
 import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
 import wangdaye.com.geometricweather.common.basic.GeoActivity
+import wangdaye.com.geometricweather.common.retrofit.TLSCompactHelper
 import wangdaye.com.geometricweather.common.utils.LanguageUtils
 import wangdaye.com.geometricweather.common.utils.helpers.BuglyHelper
 import wangdaye.com.geometricweather.settings.SettingsManager
@@ -187,6 +189,10 @@ class GeometricWeather : MultiDexApplication(),
 
     override fun onCreate() {
         super.onCreate()
+
+        val cacheCreated = TLSCompactHelper.createClientCache(baseContext.cacheDir)
+        if (!cacheCreated)
+            Log.e("GeometricWeather", "Failed to create Http client cache");
 
         instance = this
         LanguageUtils.setLanguage(


### PR DESCRIPTION
This will allow the app to respect cache requests from APIs and their potential rate limits (such as with AccuWeather, but doesn't do anything for Météo France, since their API doesn't provide any information on how their responses need to be cache...)

fixes WangDaYeeeeee/GeometricWeather#244